### PR TITLE
Facebook Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ let LinkedInButton = ({ onClick }) => (
   </Button>
 )
 
+let FacebookButton = ({ onClick }) => (
+  <Button
+    style={{ width: 175 }}
+    className="cursor-pointer"
+    color="primary"
+    onClick={onClick}
+  >
+    <Flex>
+      <i className="fa fa-facebook-square" />
+      Log in with Facebook
+    </Flex>
+  </Button>
+)
+
 let onSignIn = authPayload => {
   // Use the authentication payload to verify
   // the identity of the request using server
@@ -75,6 +89,11 @@ export default () => (
       appId="[YOUR_SALESFORCE_APP_ID]"
       onSuccess={onSignIn}
       component={SalesForceButton}
+    />
+    <FacebookAuth
+      appId="[YOUR_FACEBOOK_APP_ID]"
+      onSuccess={onSignIn}
+      component={FacebookButton}
     />
   </Flex>
 )

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ let LinkedInButton = ({ onClick }) => (
   </Button>
 )
 
+let SalesForceButton = ({ onClick }) => (
+  <Button
+    style={{ width: 175 }}
+    className="cursor-pointer"
+    color="primary"
+    onClick={onClick}
+  >
+    <Flex>
+      <i className="fa fa-salesforce" />
+      Log in with SalesForce
+    </Flex>
+  </Button>
+)
+
 let FacebookButton = ({ onClick }) => (
   <Button
     style={{ width: 175 }}
@@ -104,6 +118,7 @@ export default () => (
 - [Google](https://developers.google.com/identity/sign-in/web/backend-auth)
 - [LinkedIn](https://developer.linkedin.com/docs/oauth2) (Step 2)
 - [SalesForce](https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5)
+- [Facebook](https://developers.facebook.com/docs/facebook-login/web/)
 
 ## SalesForce server side code:
 

--- a/src/facebook.js
+++ b/src/facebook.js
@@ -1,0 +1,40 @@
+import _ from 'lodash/fp'
+import { loadScript } from './common'
+
+let getAuthPayload = (appId, onSuccess) => {
+  window.FB.api('/me', { fields: 'name, email' }, (profile) => {
+    return onSuccess({
+      type: 'facebook',
+      profile: profile,
+      authResponse: {
+        clientId: appId,
+        token: window.FB.getAccessToken(),
+      }
+    })
+  })
+}
+
+export let init = ({
+  appId,
+  version = '6.0',
+  xfbml = true,
+  status = true,
+}) => {
+  loadScript('facebook-platform', 'https://connect.facebook.net/en-US/sdk.js').then(
+    () => {
+      window.fbAsyncInit = () => {
+        window.FB.init({
+          version,
+          appId,
+          status,
+          xfbml,
+        })
+      }
+    }
+  )
+}
+
+export let onClick = ({ appId, onSuccess }) => {
+  window.FB.getAuthResponse() ? 
+    getAuthPayload(appId, onSuccess) : window.FB.login(() => getAuthPayload(appId, onSuccess))
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,8 @@ let providers = { google, linkedin, salesforce, facebook }
 export let SocialAuth = props => {
   let { provider, component: Component } = props
   let { init, onClick } = providers[provider]
-  // I don't believe the useEffect hook is necessary here.
-  useEffect(() => {
-    hasRequiredSettings(props)
-    init(props)
-  }, [])
+  hasRequiredSettings(props)
+  init(props)
   return <Component onClick={() => onClick(props)} />
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,9 @@ import { hasRequiredSettings } from './common'
 import * as google from './google'
 import * as linkedin from './linkedin'
 import * as salesforce from './salesforce'
+import * as facebook from './facebook'
 
-let providers = { google, linkedin, salesforce }
+let providers = { google, linkedin, salesforce, facebook }
 
 export let SocialAuth = props => {
   let { provider, component: Component } = props
@@ -19,6 +20,5 @@ export let SocialAuth = props => {
 
 export let GoogleAuth = props => <SocialAuth {...props} provider="google" />
 export let LinkedInAuth = props => <SocialAuth {...props} provider="linkedin" />
-export let SalesForceAuth = props => (
-  <SocialAuth {...props} provider="salesforce" />
-)
+export let SalesForceAuth = props => <SocialAuth {...props} provider="salesforce" />
+export let FacebookAuth = props => <SocialAuth {...props} provider="facebook" />


### PR DESCRIPTION
This PR implements Facebook OAuth. I tried to remain consistent with how Google OAuth was implemented in #1 as the two APIs share a lot of design practices to begin with.

Also removed the use of `useEffect` since it was raising some issues and didn't seem to be totally necessary. Feel free to add it back though if there's something I wasn't aware of!

Relevant links:
[Facebook OAuth Docs](https://developers.facebook.com/docs/facebook-login/web/)
[HTTPS Required in Production](https://developers.facebook.com/blog/post/2018/06/08/enforce-https-facebook-login/)